### PR TITLE
More robust release.sh script

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env -S bash -euo pipefail
 
 projectName="superfile"
 version="v1.0.1"
@@ -8,11 +8,11 @@ mkdir dist
 
 for os in "${osList[@]}"; do
     for arch in "${archList[@]}"; do
-        echo $projectName-$os-$version-$arch
-        mkdir ./dist/$projectName-$os-$version-$arch
-        cd ../src
-        go build -o ../release/dist/$projectName-$os-$version-$arch/spf main.go 
-        cd ../release
-        tar czf ./dist/$projectName-$os-$version-$arch.tar.gz ./dist/$projectName-$os-$version-$arch
+        echo "$projectName-$os-$version-$arch"
+        mkdir "./dist/$projectName-$os-$version-$arch"
+        cd ../src || exit
+        go build -o "../release/dist/$projectName-$os-$version-$arch/spf" main.go
+        cd ../release || exit
+        tar czf "./dist/$projectName-$os-$version-$arch.tar.gz" "./dist/$projectName-$os-$version-$arch"
     done
 done


### PR DESCRIPTION
Just a small pull request which makes the build script a bit more modular and robust. In case of an issue in the future, the script will scream earlier.

* Use more general /usr/bin/env instead of hardcoded /bin/bash with bash options for better scripts. Break early and break loud.
* Use cd … || exit in case cd fails and cause harm
* Double quote variables to prevent globbing and word splitting