### PR TITLE
Fix hardcoded sidebar folder names

### DIFF
--- a/src/components/function.go
+++ b/src/components/function.go
@@ -3,7 +3,6 @@ package components
 import (
 	"encoding/json"
 	"fmt"
-	"github.com/rkoesters/xdg/userdirs"
 	"io"
 	"log"
 	"math"
@@ -14,6 +13,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+
+	"github.com/rkoesters/xdg/userdirs"
 )
 
 func getFolder() []folder {
@@ -45,10 +46,13 @@ func getFolder() []folder {
 	json.Unmarshal(jsonData, &pinnedFolder)
 	folders := []folder{
 		{location: HomeDir, name: "󰋜 Home"},
-		{location: userdirs.Download, name: "󰏔 Downloads"},
-		{location: userdirs.Documents, name: "󰈙 Documents"},
-		{location: userdirs.Pictures, name: "󰋩 Pictures"},
-		{location: userdirs.Videos, name: "󰎁 Videos"},
+		{location: userdirs.Download, name: "󰏔 " + filepath.Base(userdirs.Download)},
+		{location: userdirs.Documents, name: "󰈙 " + filepath.Base(userdirs.Documents)},
+		{location: userdirs.Pictures, name: "󰋩 " + filepath.Base(userdirs.Pictures)},
+		{location: userdirs.Videos, name: "󰎁 " + filepath.Base(userdirs.Videos)},
+		{location: userdirs.Music, name: "♬ " + filepath.Base(userdirs.Music)},
+		{location: userdirs.Templates, name: "📝 " + filepath.Base(userdirs.Templates)},
+		{location: userdirs.PublicShare, name: "🌐 " + filepath.Base(userdirs.PublicShare)},
 	}
 
 	for i, path := range pinnedFolder {
@@ -92,7 +96,7 @@ func returnFolderElement(location string, displayDotFile bool) (folderElement []
 		fileInfo, _ := item.Info()
 		if !displayDotFile && strings.HasPrefix(fileInfo.Name(), ".") {
 			continue
-		} 
+		}
 		if fileInfo == nil {
 			continue
 		}
@@ -389,16 +393,16 @@ func ReturnMetaData(m model) model {
 }
 
 func FormatFileSize(size int64) string {
-	units := []string{" bytes", " kB", " MB", " GB", " TB", " PB", " EB"}
-
 	if size == 0 {
 		return "0B"
 	}
 
+	units := []string{"B", "KB", "MB", "GB", "TB", "PB", "EB"}
+
 	unitIndex := int(math.Floor(math.Log(float64(size)) / math.Log(1024)))
 	adjustedSize := float64(size) / math.Pow(1024, float64(unitIndex))
 
-	return fmt.Sprintf("%.2f%s", adjustedSize, units[unitIndex])
+	return fmt.Sprintf("%.2f %s", adjustedSize, units[unitIndex])
 }
 
 func DirSize(path string) int64 {

--- a/src/components/model.go
+++ b/src/components/model.go
@@ -38,8 +38,8 @@ var channel = make(chan channelMessage, 1000)
 
 func InitialModel(dir string) model {
 	var err error
-	logOutput, err = os.OpenFile(SuperFileCacheDir + logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
-  
+	logOutput, err = os.OpenFile(SuperFileCacheDir+logFile, os.O_RDWR|os.O_CREATE|os.O_APPEND, 0666)
+
 	if err != nil {
 		log.Fatalf("Error while opening superfile.log file: %v", err)
 	}
@@ -69,12 +69,7 @@ func InitialModel(dir string) model {
 	if err != nil {
 		OutPutLog("Error while reading toggleDotFile data error:", err)
 	}
-	var toggleDotFileBool bool
-	if string(toggleDotFileData) == "true" {
-		toggleDotFileBool = true
-	} else if string(toggleDotFileData) == "false" {
-		toggleDotFileBool = false
-	}
+	var toggleDotFileBool = string(toggleDotFileData) == "true"
 	LoadThemeConfig()
 	et, err = exiftool.NewExiftool()
 	if err != nil {
@@ -331,7 +326,7 @@ func (m model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 }
 
 func (m model) View() string {
-	// check is the terminal size enough
+	// Check if terminal dimensions are big enough
 	if m.fullHeight < minimumHeight || m.fullWidth < minimumWidth {
 		return TerminalSizeWarnRender(m)
 	} else if m.typingModal.open {
@@ -340,20 +335,12 @@ func (m model) View() string {
 		return WarnModalRender(m)
 	} else {
 		sideBar := SideBarRender(m)
-
 		filePanel := FilePanelRender(m)
-
 		mainPanel := lipgloss.JoinHorizontal(0, sideBar, filePanel)
-
 		processBar := ProcessBarRender(m)
-
 		metaData := MetaDataRender(m)
-
 		clipboardBar := ClipboardRender(m)
-
 		bottomBar := lipgloss.JoinHorizontal(0, processBar, metaData, clipboardBar)
-
-		// final render
 		finalRender := lipgloss.JoinVertical(0, mainPanel, bottomBar)
 
 		return lipgloss.JoinVertical(lipgloss.Top, finalRender)

--- a/src/components/modelRender.go
+++ b/src/components/modelRender.go
@@ -10,7 +10,7 @@ import (
 )
 
 func SideBarRender(m model) string {
-	s := sideBarTitle.Render("    Super Files     ")
+	s := sideBarTitle.Render("    Super Files")
 	s += "\n"
 	noPinnedFolder := true
 	for _, folder := range m.sideBarModel.pinnedModel.folder {
@@ -28,14 +28,14 @@ func SideBarRender(m model) string {
 		} else {
 			s += cursorStyle.Render(cursor) + " " + sideBarItem.Render(TruncateText(folder.name, sideBarWidth-2)) + "" + "\n"
 		}
-		if i == 4 {
+		if i == 7 {
 			s += "\n" + sideBarTitle.Render("󰐃 Pinned") + borderStyle.Render(" ───────────") + "\n\n"
 			if noPinnedFolder {
-				s += "\n" + sideBarTitle.Render("󱇰 Disk") + borderStyle.Render(" ─────────────") + "\n\n"
+				s += "\n" + sideBarTitle.Render("󱇰 Disks") + borderStyle.Render(" ─────────────") + "\n\n"
 			}
 		}
 		if folder.endPinned {
-			s += "\n" + sideBarTitle.Render("󱇰 Disk") + borderStyle.Render(" ─────────────") + "\n\n"
+			s += "\n" + sideBarTitle.Render("󱇰 Disks") + borderStyle.Render(" ─────────────") + "\n\n"
 		}
 
 	}


### PR DESCRIPTION
This commit fixes the issue mentioned in #30 of hardcoded folder names.

This revealed another issue: there can only be four directories in the predefined section. This is because of line 34 following in [components/modelRender.go](https://github.com/MHNightCat/superfile/blob/main/src/components/modelRender.go).