### PR TITLE
Actual multiarch compilation

### DIFF
--- a/release/release.sh
+++ b/release/release.sh
@@ -2,8 +2,8 @@
 
 projectName="superfile"
 version="v1.0.1"
-osList=("darwin" "freebsd" "linux" "openbsd" "netbsd")
-archList=("amd64" "arm" "arm64")
+osList=("darwin" "linux")
+archList=("amd64" "arm64")
 mkdir dist
 
 for os in "${osList[@]}"; do
@@ -11,7 +11,7 @@ for os in "${osList[@]}"; do
         echo "$projectName-$os-$version-$arch"
         mkdir "./dist/$projectName-$os-$version-$arch"
         cd ../src || exit
-        go build -o "../release/dist/$projectName-$os-$version-$arch/spf" main.go
+        env GOOS="$os" GOARCH="$arch" go build -o "../release/dist/$projectName-$os-$version-$arch/spf" main.go
         cd ../release || exit
         tar czf "./dist/$projectName-$os-$version-$arch.tar.gz" "./dist/$projectName-$os-$version-$arch"
     done


### PR DESCRIPTION
Before this commit, the compiled binaries where all the same size… They were the same binary.

Removed arm as arch platform as arm64 is what we want.

Removed the BSDs for now as there is an issue when linking exiftool. Again, not depending on it would be good.