### PR TITLE
feat: add GHA to auto bump gomod2nix manifest

### DIFF
--- a/.github/workflows/update-gomod2nix.yml
+++ b/.github/workflows/update-gomod2nix.yml
@@ -16,6 +16,7 @@ jobs:
           nix_path: nixpkgs=channel:nixos-unstable
       - name: Update checksum
         run: |
+          cd src
           nix develop --extra-experimental-features "nix-command flakes" '.#' -c "gomod2nix"
           # git push if we have a diff
           if [[ -n $(git diff) ]]; then

--- a/.github/workflows/update-gomod2nix.yml
+++ b/.github/workflows/update-gomod2nix.yml
@@ -20,8 +20,8 @@ jobs:
           nix develop --extra-experimental-features "nix-command flakes" '.#' -c "gomod2nix"
           # git push if we have a diff
           if [[ -n $(git diff) ]]; then
-            git config --global user.email "mhnightcat@github.com"
-            git config --global user.name "mhnightcat"
+            git config --global user.email "107802416+MHNightCat@users.noreply.github.com"
+            git config --global user.name "MHNightCat"
             git commit -am "chore: update gomod2nix"
             git push origin HEAD:${{ github.head_ref }}
           fi

--- a/.github/workflows/update-gomod2nix.yml
+++ b/.github/workflows/update-gomod2nix.yml
@@ -1,5 +1,9 @@
 name: Update gomod2nix.toml
-on: pull_request
+on:
+  pull_request:
+    paths:
+      - 'src/go.mod'
+      - 'src/go.sum'
 
 permissions:
   contents: write

--- a/.github/workflows/update-gomod2nix.yml
+++ b/.github/workflows/update-gomod2nix.yml
@@ -1,0 +1,26 @@
+name: Update gomod2nix.toml
+on: pull_request
+
+permissions:
+  contents: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install Nix
+        uses: cachix/install-nix-action@v26
+        with:
+          github_access_token: ${{ secrets.GITHUB_TOKEN }}
+          nix_path: nixpkgs=channel:nixos-unstable
+      - name: Update checksum
+        run: |
+          nix develop --extra-experimental-features "nix-command flakes" '.#' -c "gomod2nix"
+          # git push if we have a diff
+          if [[ -n $(git diff) ]]; then
+            git config --global user.email "mhnightcat@github.com"
+            git config --global user.name "mhnightcat"
+            git commit -am "chore: update gomod2nix"
+            git push origin HEAD:${{ github.head_ref }}
+          fi


### PR DESCRIPTION
Follow up to #68.

- Add github action to automatically update the `/src/gomod2nix.toml` manifest file for the Nix flake
- Based on this job from `direnv`: https://github.com/direnv/direnv/blob/master/script/update-gomod2nix
- Currently just runs that `nix develop ..` command on every `pull_request` in the `src/` directory
	- This command will parse the `go.mod` and then generate a new `gomod2nix.toml`. It'll then run a `git diff` to see if there are any changes compared to the last commit, and **if there are changes**, it'll create a new commit and push it

## Todo

- Maybe update Email and Username on lines 23, 24. Otherwise `git` will yell at you if you leave those fields blank when running it in the GHA runner
- Make sure your `GITHUB_TOKEN` can [write](https://stackoverflow.com/a/77453895) to this repository (for pushign changes back upstream)
- Potentially add an `if` or [`paths`](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#onpushpull_requestpull_request_targetpathspaths-ignore) conditional to the GHA to only run it when there are chagnes to the `src/go.mod` file, for example. Idk not familiar enough with the golang ecosystem on how best to limit this