### PR TITLE
Do full static link of the executable

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -2,4 +2,4 @@
 cd ./src/
 
 # build the app
-go build -o ../bin/spf
+CGO_ENABLED=0 go build -o ../bin/spf


### PR DESCRIPTION
Go binaries are much more useful when they are statically linked by default. Unless there is a good reason to depend on `libc`, there is no need to link dynamically.

This would also solve https://github.com/MHNightCat/superfile/issues/96, and make the pre-built binary more portable and more easily distributable.